### PR TITLE
Kontrolle ist eher repressiv besetzt

### DIFF
--- a/fsfw-uni-stick-vortrag.tex
+++ b/fsfw-uni-stick-vortrag.tex
@@ -116,7 +116,7 @@ Vier Freiheiten freier Software\\[4mm]
 
 Vorteile:
 \begin{itemize}
-\item Kontrolle
+\item Auditierbarkeit
 \item Erkenntnisgewinn
 \item Lizenzkosten: 0 €
 \item Anpassbarkeit an eigene Bedürfnisse


### PR DESCRIPTION
Außerdem wird Kontrolle als (falsches) Argument für proprietäres verwendet